### PR TITLE
Fixed endless loop in HandlerSocket.reader

### DIFF
--- a/handlersocket.go
+++ b/handlersocket.go
@@ -454,6 +454,7 @@ func (c *HandlerSocket) reader(nc net.Conn) {
 			if err == io.EOF {
 				break
 			}
+			break
 		}
 
 		if string(b) != "\n" {


### PR DESCRIPTION
When error from br.ReadByte() not EOF it causes endless loop and out of memory error